### PR TITLE
Fix PlugManX failing to reload plugins that use Paper's new Brigadier API

### DIFF
--- a/src/main/java/com/rylinaux/plugman/pluginmanager/ModernPaperPluginManager.java
+++ b/src/main/java/com/rylinaux/plugman/pluginmanager/ModernPaperPluginManager.java
@@ -38,6 +38,8 @@ public class ModernPaperPluginManager extends PaperPluginManager {
             Map<String, Plugin> names;
             Map<String, Command> commands;
             Map<Event, SortedSet<RegisteredListener>> listeners = null;
+            Map<String, Object> lookupNames;
+            List<Plugin> pluginList;
             boolean reloadlisteners = true;
 
             pluginManager.disablePlugin(plugin);
@@ -51,14 +53,12 @@ public class ModernPaperPluginManager extends PaperPluginManager {
 
                 Field lookupNamesField = instanceManager.getClass().getDeclaredField("lookupNames");
                 lookupNamesField.setAccessible(true);
-                Map<String, Object> lookupNames = (Map<String, Object>) lookupNamesField.get(instanceManager);
+                lookupNames = (Map<String, Object>) lookupNamesField.get(instanceManager);
 
-                lookupNames.remove(plugin.getName().toLowerCase());
 
                 Field pluginsField = instanceManager.getClass().getDeclaredField("plugins");
                 pluginsField.setAccessible(true);
-                List<Plugin> pluginList = (List<Plugin>) pluginsField.get(instanceManager);
-                pluginList.remove(plugin);
+                pluginList = (List<Plugin>) pluginsField.get(instanceManager);
 
                 pluginsField = Bukkit.getPluginManager().getClass().getDeclaredField("plugins");
                 pluginsField.setAccessible(true);
@@ -131,6 +131,11 @@ public class ModernPaperPluginManager extends PaperPluginManager {
                         }
                     }
                 }
+
+            // The plugin can only be removed from the lookup names and the plugin list AFTER the commands are unregistered, to avoid issues with commands created via Paper's Brigadier API
+            lookupNames.remove(plugin.getName().toLowerCase());
+            pluginList.remove(plugin);
+
             if (plugins != null)
                 plugins.remove(plugin);
             if (names != null)


### PR DESCRIPTION
Fixes #41

I have NOT added an automated [reload call](https://minecraft.wiki/w/Commands/reload), because reloading Minecraft's resources does have other implications. If you use vanilla's `/reload` command, ALL plugin recipes are disabled unless if the server owner reloads the affected plugins, or if the plugin owner has made that the plugin reregisterers the recipe automatically on [ServerResourcesReloadedEvent](https://jd.papermc.io/paper/1.21/io/papermc/paper/event/server/ServerResourcesReloadedEvent.html)