### PR TITLE
Fix Paper version check failing on versions that do not have a "patch" section (like 1.21)

### DIFF
--- a/src/main/java/com/rylinaux/plugman/PlugMan.java
+++ b/src/main/java/com/rylinaux/plugman/PlugMan.java
@@ -162,7 +162,9 @@ public class PlugMan extends JavaPlugin {
             Class.forName("io.papermc.paper.plugin.manager.PaperPluginManagerImpl");
             String[] version = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
 
-            int paperVersion = Integer.parseInt(version[1]) * 100 + Integer.parseInt(version[2]);
+            int paperVersion = Integer.parseInt(version[1]) * 100;
+            if (version.length >= 3)
+                paperVersion += Integer.parseInt(version[2]);
 
             this.pluginManager = paperVersion >= 2005?
                                  new ModernPaperPluginManager(new BukkitPluginManager()) :


### PR DESCRIPTION
Fixes PlugManX failing to reload plugins on Paper 1.21, fixes #44 