### PR TITLE
Fix unreliable /plugman reload, Memory leak fix with Folia support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rylinaux</groupId>
     <artifactId>PlugManX</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
     <packaging>jar</packaging>
 
     <name>PlugManX</name>

--- a/src/main/java/com/rylinaux/plugman/command/ReloadCommand.java
+++ b/src/main/java/com/rylinaux/plugman/command/ReloadCommand.java
@@ -122,8 +122,6 @@ public class ReloadCommand extends AbstractCommand {
             return;
         }
 
-        PlugMan.getInstance().getPluginUtil().reload(target);
-
-        sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format("reload.reloaded", target.getName()));
+        PlugMan.getInstance().getPluginUtil().reload(sender, target);
     }
 }

--- a/src/main/java/com/rylinaux/plugman/pluginmanager/BukkitPluginManager.java
+++ b/src/main/java/com/rylinaux/plugman/pluginmanager/BukkitPluginManager.java
@@ -344,16 +344,24 @@ public class BukkitPluginManager implements PluginManager {
 
         File pluginFile = new File(pluginDir, name + ".jar");
 
-        if (!pluginFile.isFile()) for (File f : pluginDir.listFiles())
-            if (f.getName().endsWith(".jar")) try {
-                PluginDescriptionFile desc = PlugMan.getInstance().getPluginLoader().getPluginDescription(f);
-                if (desc.getName().equalsIgnoreCase(name)) {
-                    pluginFile = f;
-                    break;
+        if (!pluginFile.isFile()) {
+            for (File f : pluginDir.listFiles()) {
+                if (f.getName().endsWith(".jar")) {
+                    try {
+                        PluginDescriptionFile desc = PlugMan.getInstance().getPluginLoader().getPluginDescription(f);
+                        if (desc.getName().equalsIgnoreCase(name)) {
+                            pluginFile = f;
+                            break;
+                        }
+                    } catch (InvalidDescriptionException e) {
+                        PlugMan.getInstance().getLogger().warning("Failed to read descriptor for " + f.getName() + " - skipping");
+                    }
                 }
-            } catch (InvalidDescriptionException e) {
+            }
+            if(!pluginFile.isFile()){
                 return PlugMan.getInstance().getMessageFormatter().format("load.cannot-find");
             }
+        }
 
         try {
             target = Bukkit.getPluginManager().loadPlugin(pluginFile);

--- a/src/main/java/com/rylinaux/plugman/pluginmanager/BukkitPluginManager.java
+++ b/src/main/java/com/rylinaux/plugman/pluginmanager/BukkitPluginManager.java
@@ -34,10 +34,7 @@ import com.rylinaux.plugman.util.BukkitCommandWrapUseless;
 import com.rylinaux.plugman.util.StringUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandMap;
-import org.bukkit.command.PluginCommand;
-import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.command.*;
 import org.bukkit.event.Event;
 import org.bukkit.plugin.*;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -333,16 +330,6 @@ public class BukkitPluginManager implements PluginManager {
     /**
      * Loads and enables a plugin.
      *
-     * @param plugin plugin to load
-     * @return status message
-     */
-    private String load(Plugin plugin) {
-        return this.load(plugin.getName());
-    }
-
-    /**
-     * Loads and enables a plugin.
-     *
      * @param name plugin's name
      * @return status message
      */
@@ -470,20 +457,6 @@ public class BukkitPluginManager implements PluginManager {
         }
     }
 
-
-    /**
-     * Reload a plugin.
-     *
-     * @param plugin the plugin to reload
-     */
-    @Override
-    public void reload(Plugin plugin) {
-        if (plugin != null) {
-            this.unload(plugin);
-            this.load(plugin);
-        }
-    }
-
     /**
      * Reload all plugins.
      */
@@ -491,7 +464,7 @@ public class BukkitPluginManager implements PluginManager {
     public void reloadAll() {
         for (Plugin plugin : Bukkit.getPluginManager().getPlugins())
             if (!this.isIgnored(plugin) && !this.isPaperPlugin(plugin))
-                this.reload(plugin);
+                this.reload(null, plugin);
     }
 
     /**

--- a/src/main/java/com/rylinaux/plugman/pluginmanager/ModernPaperPluginManager.java
+++ b/src/main/java/com/rylinaux/plugman/pluginmanager/ModernPaperPluginManager.java
@@ -5,6 +5,7 @@ import com.rylinaux.plugman.PlugMan;
 import com.rylinaux.plugman.api.GentleUnload;
 import com.rylinaux.plugman.api.PlugManAPI;
 import com.rylinaux.plugman.util.BukkitCommandWrapUseless;
+import com.tcoded.folialib.FoliaLib;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.PluginCommand;
@@ -19,6 +20,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 public class ModernPaperPluginManager extends PaperPluginManager {
@@ -182,14 +184,22 @@ public class ModernPaperPluginManager extends PaperPluginManager {
                 e.printStackTrace();
                 return PlugMan.getInstance().getMessageFormatter().format("unload.failed", name);
             }
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    // schedule an empty BukkitRunnable to clear/reset the "head" field in CraftScheduler.
-                    // that field can keep plugin classes loaded, and scheduling an empty runnable
-                    // seems nicer and less harmful than clearing that field with reflection
-                }
-            }.runTask(PlugMan.getInstance());
+            if (this.isFolia()) {
+                com.tcoded.folialib.FoliaLib foliaLib = new com.tcoded.folialib.FoliaLib(PlugMan.getInstance());
+                foliaLib.getImpl().runAsync(() -> {
+                    // attempt to do the same thing for folia
+                });
+            } else {
+                new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        // schedule an empty BukkitRunnable to clear/reset the "head" field in CraftScheduler.
+                        // that field can keep plugin classes loaded, and scheduling an empty runnable
+                        // seems nicer and less harmful than clearing that field with reflection
+                    }
+                }.runTask(PlugMan.getInstance());
+            }
+
         }
 
         if (!(PlugMan.getInstance().getBukkitCommandWrap() instanceof BukkitCommandWrapUseless))

--- a/src/main/java/com/rylinaux/plugman/pluginmanager/PluginManager.java
+++ b/src/main/java/com/rylinaux/plugman/pluginmanager/PluginManager.java
@@ -1,6 +1,8 @@
 package com.rylinaux.plugman.pluginmanager;
 
+import com.rylinaux.plugman.PlugMan;
 import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
 import java.util.List;
@@ -147,11 +149,31 @@ public interface PluginManager {
 
 
     /**
+     * Loads and enables a plugin.
+     *
+     * @param plugin plugin to load
+     * @return status message
+     */
+    default String load(Plugin plugin) {
+        return this.load(plugin.getName());
+    }
+
+    /**
      * Reload a plugin.
      *
      * @param plugin the plugin to reload
      */
-    void reload(Plugin plugin);
+    default void reload(CommandSender sender, Plugin plugin){
+        if (plugin != null) {
+            String unloadOutput = this.unload(plugin);
+            if(sender != null) sender.sendMessage(unloadOutput);
+            String loadOutput = this.load(plugin);
+            if(sender != null) {
+                sender.sendMessage(loadOutput);
+                sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format("reload.reloaded", plugin.getName()));
+            }
+        }
+    }
 
     /**
      * Reload all plugins.


### PR DESCRIPTION
Supercedes pull #48 by including its changes.

This PR fixes a few problems in both that PR as well as base PlugManX

- Fixes Folia support in the memory leak related bugfix in #48
- Makes the reload process more verbose by sending the respective load/unload messages to make diagnosing issues easier
  - In-game reloads should now have zero ambiguity as to if they were successful or not.
- Fixed long standing bug where .jar files with invalid or missing `plugin.yml` files cause the plugins folder scan to end earlier than it should, resulting in the `load()` call after the `unload()` failing.
  - This was a silent, ambiguous, seemingly random failure in the past due to the loss of information via the old reload patterns. In essence, if you were doing a `/plugman reload` that required a follow-up `/plugman load` after, this is the fix.
- Added some logging to note when plugin descriptor scans fail in console to assist admins/devs

This PR bumps to v2.4.2 as well, though feel free to adjust per your own Semvar wishes